### PR TITLE
Update default.json for localized odometer readings

### DIFF
--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -25,7 +25,8 @@
   ]},
 { "hdr": "7C6", "rax": "7CE", "fcm1": true, "cmd": {"22": "B002"}, "freq": 5,
   "signals": [
-    {"id": "EV9_ODO", "path": "Trips", "fmt": {"bix": 72, "len": 24, "max": 4294967295, "unit": "kilometers" }, "name": "Odometer", "suggestedMetric": "odometer"}
+    {"id": "EV9_ODO_KM", "path": "Trips", "fmt": {"bix": 48, "len": 24, "max": 4294967295, "unit": "kilometers" }, "name": "Odometer (Metric)", "suggestedMetric": "odometer"},
+    {"id": "EV9_ODO_MI", "path": "Trips", "fmt": {"bix": 72, "len": 24, "max": 4294967295, "unit": "miles" }, "name": "Odometer (Imperial)", "suggestedMetric": "odometer"}
   ]},
 { "hdr": "7E4", "rax": "7EC", "fcm1": true, "cmd": {"22": "0101"}, "freq": 1,
   "signals": [


### PR DESCRIPTION
Updating naming and measure for imperial odometer reading. Added signal for metric odometer reading. Despite being in separate locations, the car does not report these simultaneously but only depending on the car's current localization setting.